### PR TITLE
Adds new features to the spike rule

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1100,6 +1100,10 @@ default 50, unique terms.
 
 ``query_key``: Counts of documents will be stored independently for each value of ``query_key``.
 
+``scan_entire_timeframe``: If this value is set, not only the `'buffer_time`` (or in case of ``use_count_query`` or ``use_terms_query``
+the ``run_every`` time) is queried every run but the whole ``timeframe``. With count or terms queries this can lead to wrong data
+because some of the data queried may have been queried in the previous run and due to missing ids it can't be deduplicated.
+
 Flatline
 ~~~~~~~~
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -955,6 +955,8 @@ A table with arguments for different metrics is below.
     | Metric              | Options                                                        |
     +=====================+================================================================+
     | percentile          | ``percentile`` (float between 0 and 1, default: 0.95) optional |
+    |                     | ``params`` These parameters (a,b,c,d) are used to calculate    |
+    |                     |     the percentile. See below for more info.                   |
     +---------------------+----------------------------------------------------------------+
     | mean                |                                                                |
     +---------------------+----------------------------------------------------------------+
@@ -964,7 +966,8 @@ A table with arguments for different metrics is below.
     +---------------------+----------------------------------------------------------------+
     | mad                 |                                                                |
     +---------------------+----------------------------------------------------------------+
-    | interquartile_range |                                                                |
+    | interquartile_range | ``params`` These parameters (a,b,c,d) are used to calculate    |
+    |                     | the quartiles. See percentile parameters below for more info.  |
     +---------------------+----------------------------------------------------------------+
     | sum                 |                                                                |
     +---------------------+----------------------------------------------------------------+
@@ -974,6 +977,23 @@ A table with arguments for different metrics is below.
     +---------------------+----------------------------------------------------------------+
     | fixed               |                                                                |
     +---------------------+----------------------------------------------------------------+
+
+..note:: Percentile parameters ``a, b, c, d``: These parameters are used to calculated the percentile.
+    For a sorted list ``s`` of length ``n`` the calculation is as follows:
+    The first internal parameter is ``x = a + (n + b) * q`` . If ``x`` is an integer the result is s[x]. Otherwise the result
+    is ``s[floor(x)] + (s[ceil(x)] - s[floor(x)]) * (c + d * fractional_part(x))``.
+    The default choice for a, b, c, d = (0, 0, 1, 0). Common choices of parameter include:
+    (0,   0,   1, 0)        inverse empirical CDF (default)
+    (0,   0,   0, 1)        linear interpolation (California method)
+    (1/2, 0,   0, 0)        element numbered closest to q * n
+    (1/2, 0,   0, 1)        linear interpolation (hydrologist method)
+    (0,   1,   0, 1)        mean-based estimate (Weibull method)
+    (1,   -1,  0, 1)        mode-based estimate
+    (1/3, 1/3, 0, 1)        median-based estimate
+    (3/8, 1/4, 0, 1)        normal distribution estimate
+    Whenever ``d = 0`` the result is always equal to an element in the list.
+    For the median (1/2, 0, 0, 1) is used.
+    The default for the quartiles in the interquartile_range are the default parameters.
 
 ``threshold_ref``: The minimum reference metric value for an alert to trigger. For example, if
 ``spike_height: 3`` and ``threshold_ref: 10``, then the reference metric value must be at least 10 and the current value at

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -938,14 +938,19 @@ The default is an empty timeframe (0 seconds).
 
 ``spike_ref_metric``: This metric will be calculated over the reference event windows. When this metric is used, there must
 be more then one reference window. For example, ``mean`` calculates the mean value of the counts in the reference windows
-and for an alert the count in the current window must be ``spike_height`` time higher or lower this value.
+and for an alert the count in the current window must be ``spike_height`` time higher or lower this value. The metric can
+be one of the metrics listed below or an importable function which takes the data as a first argument, for example
+``statistics.harmonic_mean``. The default metric is ``mean``.
 
 ``spike_ref_metric_args``: Arguments for the ``spike_ref_metric``. The arguments are a mapping (e.g. ``percentile: 0.5``)
 A table with arguments for different metrics is below.
 
 ``spike_height_metric``: This metric will be calculated over the reference windows and should be logically one of the deviation metrics.
 To alert the count in the current window must be ``spike_height`` * the value of spike_height_metric times higher or
-lower than the value of the reference window.
+lower than the value of the reference window. The metric can be one of the metrics listed below or an importable
+function which takes the data as a first argument, for example ``statistics.harmonic_mean``. The default metric is ``fixed``,
+which is a static value of 1. If the value is fixed, the spike height is interpreted as ``ref * spike_height``, else as
+``ref + spike_height_metric * spike_height``.
 
 ``spike_heigh_metric_args``: Arguments for the ``spike_height_metric``. The arguments are a mapping (e.g. ``percentile: 0.5``)
 A table with arguments for different metrics is below.
@@ -958,11 +963,13 @@ A table with arguments for different metrics is below.
     |                     | ``params`` These parameters (a,b,c,d) are used to calculate    |
     |                     |     the percentile. See below for more info.                   |
     +---------------------+----------------------------------------------------------------+
-    | mean                |                                                                |
+    | mean                | Uses the mean function from the python statistics module       |
     +---------------------+----------------------------------------------------------------+
-    | median              |                                                                |
+    | median              | Uses the median function from the python statistics module     |
     +---------------------+----------------------------------------------------------------+
-    | standard_deviation  |                                                                |
+    | stdev               | Uses the stdev function from the python statistics module.     |
+    +---------------------+----------------------------------------------------------------+
+    | variance            | Uses the variance function from the python statistics module.  |
     +---------------------+----------------------------------------------------------------+
     | mad                 |                                                                |
     +---------------------+----------------------------------------------------------------+
@@ -992,8 +999,7 @@ A table with arguments for different metrics is below.
     (1/3, 1/3, 0, 1)        median-based estimate
     (3/8, 1/4, 0, 1)        normal distribution estimate
     Whenever ``d = 0`` the result is always equal to an element in the list.
-    For the median (1/2, 0, 0, 1) is used.
-    The default for the quartiles in the interquartile_range are the default parameters.
+    The default params for the quartiles in the interquartile_range are the default parameters of the percentile function.
 
 ``threshold_ref``: The minimum reference metric value for an alert to trigger. For example, if
 ``spike_height: 3`` and ``threshold_ref: 10``, then the reference metric value must be at least 10 and the current value at

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -955,7 +955,7 @@ which is a static value of 1. If the value is fixed, the spike height is interpr
 ``spike_heigh_metric_args``: Arguments for the ``spike_height_metric``. The arguments are a mapping (e.g. ``percentile: 0.5``)
 A table with arguments for different metrics is below.
 
-..note:: Available metrics with options
+.. note::
     +---------------------+----------------------------------------------------------------+
     | Metric              | Options                                                        |
     +=====================+================================================================+
@@ -985,19 +985,22 @@ A table with arguments for different metrics is below.
     | fixed               |                                                                |
     +---------------------+----------------------------------------------------------------+
 
-..note:: Percentile parameters ``a, b, c, d``: These parameters are used to calculated the percentile.
+.. note::
+    Percentile parameters ``a, b, c, d``: These parameters are used to calculated the percentile.
     For a sorted list ``s`` of length ``n`` the calculation is as follows:
     The first internal parameter is ``x = a + (n + b) * q`` . If ``x`` is an integer the result is s[x]. Otherwise the result
     is ``s[floor(x)] + (s[ceil(x)] - s[floor(x)]) * (c + d * fractional_part(x))``.
-    The default choice for a, b, c, d = (0, 0, 1, 0). Common choices of parameter include:
-    (0,   0,   1, 0)        inverse empirical CDF (default)
-    (0,   0,   0, 1)        linear interpolation (California method)
-    (1/2, 0,   0, 0)        element numbered closest to q * n
-    (1/2, 0,   0, 1)        linear interpolation (hydrologist method)
-    (0,   1,   0, 1)        mean-based estimate (Weibull method)
-    (1,   -1,  0, 1)        mode-based estimate
-    (1/3, 1/3, 0, 1)        median-based estimate
-    (3/8, 1/4, 0, 1)        normal distribution estimate
+    The default choice for a, b, c, d = (0, 0, 1, 0). Common choices of parameter include::
+
+        (0,   0,   1, 0)        inverse empirical CDF (default)
+        (0,   0,   0, 1)        linear interpolation (California method)
+        (1/2, 0,   0, 0)        element numbered closest to q * n
+        (1/2, 0,   0, 1)        linear interpolation (hydrologist method)
+        (0,   1,   0, 1)        mean-based estimate (Weibull method)
+        (1,   -1,  0, 1)        mode-based estimate
+        (1/3, 1/3, 0, 1)        median-based estimate
+        (3/8, 1/4, 0, 1)        normal distribution estimate
+
     Whenever ``d = 0`` the result is always equal to an element in the list.
     The default params for the quartiles in the interquartile_range are the default parameters of the percentile function.
 

--- a/elastalert/loaders/schema.yaml
+++ b/elastalert/loaders/schema.yaml
@@ -93,7 +93,7 @@ oneOf:
     required: [spike_height, spike_type, timeframe]
     properties:
       type: {enum: [spike]}
-      spike_height: {type: number}
+      spike_height: {type: number, minimum: 1}
       spike_type: {enum: ["up", "down", "both"]}
       timeframe: *timeframe
       use_count_query: {type: boolean}
@@ -102,7 +102,7 @@ oneOf:
       alert_on_new_data: {type: boolean}
       threshold_ref: {type: integer}
       threshold_cur: {type: integer}
-      ref_window_count: {type: integer}
+      ref_window_count: {type: integer, minimum: 1}
       gap_timeframe: *timeframe
       spike_ref_metric: {enum: ["percentile", "mean", "median", "standard_deviation", "mad", "interquartile_range", "sum", "min", "max", "fixed"]}
       spike_ref_metric_args:
@@ -110,6 +110,10 @@ oneOf:
           - title: percentile
             properties:
               percentile: {type: number, minimum: 0, maximum: 1}
+              params: {type: array, items: [{type: number}, {type: number}, {type: number}, {type: number}]}
+          - title: interquartile_range
+            properties:
+              params: {type: array, items: [{type: number}, {type: number}, {type: number}, {type: number}]}
 
   - title: Spike Aggregation
     required: [spike_height, spike_type, timeframe]

--- a/elastalert/loaders/schema.yaml
+++ b/elastalert/loaders/schema.yaml
@@ -97,12 +97,19 @@ oneOf:
       spike_type: {enum: ["up", "down", "both"]}
       timeframe: *timeframe
       use_count_query: {type: boolean}
-      doc_type: {type: string}
       use_terms_query: {type: boolean}
       terms_size: {type: integer}
       alert_on_new_data: {type: boolean}
       threshold_ref: {type: integer}
       threshold_cur: {type: integer}
+      ref_window_count: {type: integer}
+      gap_timeframe: *timeframe
+      spike_ref_metric: {enum: ["percentile", "mean", "median", "standard_deviation", "mad", "interquartile_range", "sum", "min", "max", "fixed"]}
+      spike_ref_metric_args:
+        oneOf:
+          - title: percentile
+            properties:
+              percentile: {type: number, minimum: 0, maximum: 1}
 
   - title: Spike Aggregation
     required: [spike_height, spike_type, timeframe]

--- a/elastalert/loaders/schema.yaml
+++ b/elastalert/loaders/schema.yaml
@@ -104,8 +104,18 @@ oneOf:
       threshold_cur: {type: integer}
       ref_window_count: {type: integer, minimum: 1}
       gap_timeframe: *timeframe
-      spike_ref_metric: {enum: ["percentile", "mean", "median", "standard_deviation", "mad", "interquartile_range", "sum", "min", "max", "fixed"]}
+      spike_ref_metric: {enum: ["percentile", "mean", "median", "standard_deviation", "mad", "interquartile_range", "sum", "min", "max"]}
       spike_ref_metric_args:
+        oneOf:
+          - title: percentile
+            properties:
+              percentile: {type: number, minimum: 0, maximum: 1}
+              params: {type: array, items: [{type: number}, {type: number}, {type: number}, {type: number}]}
+          - title: interquartile_range
+            properties:
+              params: {type: array, items: [{type: number}, {type: number}, {type: number}, {type: number}]}
+      spike_height_metric: {enum: ["percentile", "mean", "median", "standard_deviation", "mad", "interquartile_range", "sum", "min", "max", "fixed"]}
+      spike_height_metric_args:
         oneOf:
           - title: percentile
             properties:

--- a/elastalert/ruletypes/ruletype.py
+++ b/elastalert/ruletypes/ruletype.py
@@ -43,12 +43,13 @@ class RuleType(Rule, metaclass=ABCMeta):
 
         :param event: The matching event, a dictionary of terms.
         """
+        event = copy.deepcopy(event)
         # Convert datetime's back to timestamps
         ts = self.rules.get("timestamp_field")
         if ts in event:
             event[ts] = dt_to_ts(event[ts])
 
-        self.matches.append(copy.deepcopy(event))
+        self.matches.append(event)
 
     def get_match_str(self, match):
         """ Returns a string that gives more context about a match.

--- a/elastalert/ruletypes/spike_rule.py
+++ b/elastalert/ruletypes/spike_rule.py
@@ -76,9 +76,10 @@ class SpikeRule(RuleType):
                     continue
             for window in self.windows[qk]:
                 # adds a dummy event so that the duration is until now and clears old events
-                window.data.add({self.ts_field: timestamp})
-                window.clean_old_events()
-                del window.data[-1]
+                if window.timeframe > datetime.timedelta(seconds=0):
+                    window.data.add(({self.ts_field: timestamp}, 0))
+                    window.clean_old_events()
+                    del window.data[-1]
 
     def init_windows(self, qk: str):
         """

--- a/elastalert/ruletypes/spike_rule.py
+++ b/elastalert/ruletypes/spike_rule.py
@@ -1,241 +1,186 @@
-import logging
+import datetime
+from typing import Dict, List
 
 from elastalert.exceptions import EAConfigException
 from elastalert.queries.elasticsearch_query import (
-    ElasticsearchCountQuery,
     ElasticsearchQuery,
-    ElasticsearchTermQuery,
+    ElasticsearchSpikeCountQuery,
+    ElasticsearchSpikeTermQuery,
 )
 from elastalert.queries.query_factory import QueryFactory
 from elastalert.ruletypes import RuleType
+from elastalert.utils import arithmetic
 from elastalert.utils.event_window import CountEventWindow
-from elastalert.utils.time import pretty_ts
 from elastalert.utils.util import hashable, lookup_es_key, new_get_event_ts
-
-log = logging.getLogger(__name__)
 
 
 class SpikeRule(RuleType):
-    """ A rule that uses two sliding windows to compare relative event frequency. """
-
-    required_options = frozenset(["timeframe", "spike_height", "spike_type"])
-
-    def init_query_factory(self):
-        query_class = ElasticsearchQuery
-        callback = self.add_data
-        if self.rule_config.get("use_count_query"):
-            query_class = ElasticsearchCountQuery
-            callback = self.add_count_data
-        elif self.rule_config.get("use_terms_query"):
-            query_class = ElasticsearchTermQuery
-            callback = self.add_terms_data
-        return QueryFactory(query_class, self.rule_config, callback, self.es)
-
-    def __init__(self, *args, **kwargs):
-        super(SpikeRule, self).__init__(*args, **kwargs)
-        self.timeframe = self.rules["timeframe"]
-
-        self.ref_windows = {}
-        self.cur_windows = {}
-
+    def __init__(self, rule_config, *args, **kwargs):
+        super().__init__(rule_config, *args, **kwargs)
         self.ts_field = self.rules.get("timestamp_field", "@timestamp")
-        self.get_ts = new_get_event_ts(self.ts_field)
-        self.first_event = {}
-        self.skip_checks = {}
-
-        self.field_value = self.rules.get("field_value")
-
         self.ref_window_filled_once = False
+        self.get_ts = new_get_event_ts(self.ts_field)
 
-    def add_count_data(self, data):
-        """ Add count data to the rule. Data should be of the form {ts: count}. """
-        if len(data) > 1:
+        self.timeframe = self.rule_config["timeframe"]
+        self.gap_timeframe = self.rule_config.get(
+            "gap_timeframe", datetime.timedelta(seconds=0)
+        )
+
+        self.ref_window_count = self.rule_config.get("ref_window_count", 1)
+        if self.ref_window_count < 1:
+            raise EAConfigException("ref_count must be >= 1")
+        self.spike_height_metric = arithmetic.mapping.get(
+            self.rule_config.get("spike_height_metric", "fixed"), lambda x: 1
+        )
+        self.spike_height_metric_args = self.rule_config.get(
+            "spike_height_metric_args", dict()
+        )
+        self.spike_ref_metric = arithmetic.mapping[
+            self.rule_config.get("spike_ref_metric", "mean")
+        ]
+        self.spike_ref_metric_args = self.rule_config.get(
+            "spike_ref_metric_args", dict()
+        )
+        if (
+            self.rule_config.get("spike_ref_metric", "fixed") != "fixed"
+            and self.ref_window_count == 1
+        ):
             raise EAConfigException(
-                "add_count_data can only accept one count at a time"
+                "If spike_height_ref is set to something other than fixed, ref_count must be > 1"
             )
-        for ts, count in data.items():
-            self.handle_event({self.ts_field: ts}, count, "all")
 
-    def add_terms_data(self, terms):
-        for timestamp, buckets in terms.items():
-            for bucket in buckets:
-                count = bucket["doc_count"]
-                event = {
-                    self.ts_field: timestamp,
-                    self.rules["query_key"]: bucket["key"],
-                }
-                key = bucket["key"]
-                self.handle_event(event, count, key)
+        self.windows = dict()
+        self.first_event = dict()
 
-    def add_data(self, data):
-        for event in data:
-            qk = self.rules.get("query_key", "all")
+    def init_query_factory(self) -> QueryFactory:
+        if self.rule_config.get("use_count_query"):
+            return QueryFactory(
+                ElasticsearchSpikeCountQuery, self.rule_config, self.add_count_data
+            )
+        elif self.rule_config.get("use_terms_query"):
+            return QueryFactory(
+                ElasticsearchSpikeTermQuery, self.rule_config, self.add_terms_data
+            )
+        else:
+            return QueryFactory(ElasticsearchQuery, self.rule_config, self.add_data)
+
+    def garbage_collect(self, timestamp):
+        for qk in list(self.windows.keys()):
+            # If we havn't seen this key in a long time, forget it
             if qk != "all":
-                qk = hashable(lookup_es_key(event, qk))
-                if qk is None:
-                    qk = "other"
-            if self.field_value is not None:
-                count = lookup_es_key(event, self.field_value)
-                if count is not None:
-                    try:
-                        count = int(count)
-                    except ValueError:
-                        log.warn(
-                            "{} is not a number: {}".format(self.field_value, count)
-                        )
-                    else:
-                        self.handle_event(event, count, qk)
-            else:
-                self.handle_event(event, 1, qk)
+                for window in self.windows[qk]:
+                    if window.count() != 0:
+                        break
+                else:
+                    self.windows.pop(qk)
+                    continue
+            for window in self.windows[qk]:
+                # adds a dummy event so that the duration is until now and clears old events
+                window.data.add({self.ts_field: timestamp})
+                window.clean_old_events()
+                del window.data[-1]
 
-    def clear_windows(self, qk, event):
-        # Reset the state and prevent alerts until windows filled again
-        self.ref_windows[qk].clear()
-        self.first_event.pop(qk)
-        self.skip_checks[qk] = (
-            lookup_es_key(event, self.ts_field) + self.rules["timeframe"] * 2
+    def init_windows(self, qk: str):
+        """
+        Initializes the event windows for a query key
+        :param qk: The query key
+        """
+        self.windows[qk] = [CountEventWindow(self.timeframe, get_timestamp=self.get_ts)]
+        for i in range(self.ref_window_count - 1):
+            self.windows[qk].append(
+                CountEventWindow(
+                    self.timeframe,
+                    self.windows[qk][-1].append,
+                    get_timestamp=self.get_ts,
+                )
+            )
+        self.windows[qk].append(
+            CountEventWindow(
+                self.gap_timeframe,
+                self.windows[qk][-1].append,
+                get_timestamp=self.get_ts,
+            )
+        )
+        self.windows[qk].append(
+            CountEventWindow(
+                self.timeframe, self.windows[qk][-1].append, get_timestamp=self.get_ts
+            )
         )
 
-    def handle_event(self, event, count, qk="all"):
+    def handle_event(self, event: dict, count: int, qk: str = "all"):
         self.first_event.setdefault(qk, event)
-
-        self.ref_windows.setdefault(
-            qk, CountEventWindow(self.timeframe, get_timestamp=self.get_ts)
-        )
-        self.cur_windows.setdefault(
-            qk,
-            CountEventWindow(self.timeframe, self.ref_windows[qk].append, self.get_ts),
-        )
-
-        self.cur_windows[qk].append((event, count))
-
+        if qk not in self.windows:
+            self.init_windows(qk)
+        self.windows[qk][-1].append((event, count))
         # Don't alert if ref window has not yet been filled for this key AND
         if (
-            lookup_es_key(event, self.ts_field) - self.first_event[qk][self.ts_field]
-            < self.rules["timeframe"] * 2
+            not self.rule_config.get("alert_on_new_data", False)
+            and lookup_es_key(event, self.ts_field)
+            - self.first_event[qk][self.ts_field]
+            < (self.timeframe * (self.ref_window_count + 1)) + self.gap_timeframe
         ):
             # ElastAlert has not been running long enough for any alerts OR
             if not self.ref_window_filled_once:
                 return
-            # This rule is not using alert_on_new_data (with query_key) OR
+            # This rule is not using alert_on_new_data (with query_key)
             if not (
                 self.rules.get("query_key") and self.rules.get("alert_on_new_data")
-            ):
-                return
-            # An alert for this qk has recently fired
-            if (
-                qk in self.skip_checks
-                and lookup_es_key(event, self.ts_field) < self.skip_checks[qk]
             ):
                 return
         else:
             self.ref_window_filled_once = True
 
-        if self.field_value is not None:
-            if self.find_matches(
-                self.ref_windows[qk].mean(), self.cur_windows[qk].mean()
-            ):
-                # skip over placeholder events
-                for match, count in self.cur_windows[qk].data:
-                    if "placeholder" not in match:
-                        break
-                self.add_match(match, qk)
-                self.clear_windows(qk, match)
-        else:
-            if self.find_matches(
-                self.ref_windows[qk].count(), self.cur_windows[qk].count()
-            ):
-                # skip over placeholder events which have count=0
-                for match, count in self.cur_windows[qk].data:
-                    if count:
-                        break
-
-                self.add_match(match, qk)
-                self.clear_windows(qk, match)
-
-    def add_match(self, match, qk):
-        extra_info = {}
-        if self.field_value is None:
-            spike_count = self.cur_windows[qk].count()
-            reference_count = self.ref_windows[qk].count()
-        else:
-            spike_count = self.cur_windows[qk].mean()
-            reference_count = self.ref_windows[qk].mean()
-        extra_info = {"spike_count": spike_count, "reference_count": reference_count}
-
-        match = dict(list(match.items()) + list(extra_info.items()))
-
-        super(SpikeRule, self).add_match(match)
-
-    def find_matches(self, ref, cur):
-        """ Determines if an event spike or dip happening. """
-        # Apply threshold limits
-        if self.field_value is None:
-            if cur < self.rules.get("threshold_cur", 0) or ref < self.rules.get(
-                "threshold_ref", 0
-            ):
-                return False
-        elif ref is None or ref == 0 or cur is None or cur == 0:
-            return False
-
+        cur = self.windows[qk][-1].count()
+        ref_data = [
+            self.windows[qk][i].count() for i in range(len(self.windows[qk]) - 2)
+        ]
+        ref = self.spike_ref_metric(ref_data, **self.spike_ref_metric_args)
+        ref_metric = self.spike_height_metric(ref_data, **self.spike_height_metric_args)
+        if cur < self.rules.get("threshold_cur", 0) or ref < self.rules.get(
+            "threshold_ref", 0
+        ):
+            return
         spike_up, spike_down = False, False
-        if cur <= ref / self.rules["spike_height"]:
-            spike_down = True
-        if cur >= ref * self.rules["spike_height"]:
+        if cur >= ref * ref_metric * self.rule_config["spike_height"]:
             spike_up = True
+        if cur <= ref / (ref_metric * self.rule_config["spike_height"]):
+            spike_down = True
 
         if (self.rules["spike_type"] in ["both", "up"] and spike_up) or (
             self.rules["spike_type"] in ["both", "down"] and spike_down
         ):
-            return True
-        return False
+            extra_info = {
+                "spike_count": cur,
+                "reference_count": ref,
+                "reference_metric_value": ref_metric,
+            }
+            event = {"events": [item[0] for item in self.windows[qk][-1].data]}
+            match = dict(list(event.items()) + list(extra_info.items()))
+            self.add_match(match)
 
     def get_match_str(self, match):
-        if self.field_value is None:
-            message = "An abnormal number (%d) of events occurred around %s.\n" % (
-                match["spike_count"],
-                pretty_ts(
-                    match[self.rules["timestamp_field"]],
-                    self.rules.get("use_local_time"),
-                ),
-            )
-            message += (
-                "Preceding that time, there were only %d events within %s\n\n"
-                % (match["reference_count"], self.rules["timeframe"])
-            )
-        else:
-            message = (
-                "An abnormal average value (%.2f) of field '%s' occurred around %s.\n"
-                % (
-                    match["spike_count"],
-                    self.field_value,
-                    pretty_ts(
-                        match[self.rules["timestamp_field"]],
-                        self.rules.get("use_local_time"),
-                    ),
-                )
-            )
-            message += (
-                "Preceding that time, the field had an average value of (%.2f) within %s\n\n"
-                % (match["reference_count"], self.rules["timeframe"])
-            )
-        return message
+        return ""  # TODO
 
-    def garbage_collect(self, ts):
-        # Windows are sized according to their newest event
-        # This is a placeholder to accurately size windows in the absence of events
-        for qk in list(self.cur_windows.keys()):
-            # If we havn't seen this key in a long time, forget it
-            if (
-                qk != "all"
-                and self.ref_windows[qk].count() == 0
-                and self.cur_windows[qk].count() == 0
-            ):
-                self.cur_windows.pop(qk)
-                self.ref_windows.pop(qk)
-                continue
-            placeholder = {self.ts_field: ts, "placeholder": True}
-            # The placeholder may trigger an alert, in which case, qk will be expected
+    def add_data(self, data: List[dict]):
+        for event in data:
+            qk = self.rule_config.get("query_key", "all")
             if qk != "all":
-                placeholder.update({self.rules["query_key"]: qk})
-            self.handle_event(placeholder, 0, qk)
+                qk = hashable(lookup_es_key(event, qk))
+                if qk is None:
+                    qk = "other"
+            self.handle_event(event, 1, qk)
+
+    def add_count_data(self, counts: Dict[datetime.datetime, int]):
+        ts, count = counts.items()
+        self.handle_event({self.ts_field: ts}, count)
+
+    def add_terms_data(self, terms: Dict[datetime.datetime, List[dict]]):
+        for timestamp, buckets in terms.items():
+            for bucket in buckets:
+                count = bucket["doc_count"]
+                event = {
+                    self.ts_field: timestamp,
+                    self.rule_config["query_key"]: bucket["key"],
+                }
+                key = bucket["key"]
+                self.handle_event(event, count, key)

--- a/elastalert/ruletypes/spike_rule.py
+++ b/elastalert/ruletypes/spike_rule.py
@@ -10,7 +10,6 @@ from elastalert.queries.elasticsearch_query import (
 from elastalert.queries.query_factory import QueryFactory
 from elastalert.ruletypes import RuleType
 from elastalert.utils import arithmetic
-from elastalert.utils.arithmetic import mean
 from elastalert.utils.event_window import CountEventWindow
 from elastalert.utils.time import pretty_ts
 from elastalert.utils.util import hashable, lookup_es_key, new_get_event_ts
@@ -29,13 +28,13 @@ class SpikeRule(RuleType):
         )
 
         self.ref_window_count = self.rule_config.get("ref_window_count", 1)
-        self.spike_ref_metric = arithmetic.mapping[
+        self.spike_ref_metric = arithmetic.Mapping.get(
             self.rule_config.get("spike_ref_metric", "mean")
-        ]
+        )
         self.spike_ref_metric_args = self.rule_config.get(
             "spike_ref_metric_args", dict()
         )
-        self.spike_height_metric = arithmetic.mapping.get(
+        self.spike_height_metric = arithmetic.Mapping.get(
             self.rule_config.get("spike_height_metric", "fixed"), lambda ref: 1
         )
         self.spike_height_metric_args = self.rule_config.get(

--- a/elastalert/utils/arithmetic.py
+++ b/elastalert/utils/arithmetic.py
@@ -1,10 +1,12 @@
 from decimal import Decimal
 from math import ceil, floor
 from statistics import StatisticsError, mean, median, stdev, variance
-from typing import List, Tuple, Union
+from typing import List, Tuple, TypeVar
 
 from elastalert.exceptions import EAException
 from elastalert.utils.util import get_module
+
+Numeric = TypeVar("Numeric", int, float)
 
 
 def fractional_part(x: float) -> float:
@@ -17,11 +19,9 @@ def fractional_part(x: float) -> float:
 
 
 def percentile(
-    data: List[Union[int, float]],
+    data: List[Numeric],
     percentile: float = 0.95,
-    params: Tuple[
-        Union[int, float], Union[int, float], Union[int, float], Union[int, float]
-    ] = (0, 0, 1, 0),
+    params: Tuple[Numeric, Numeric, Numeric, Numeric] = (0, 0, 1, 0),
 ) -> float:
     """
     Calculates the nth percentile of a list of values
@@ -52,7 +52,7 @@ def percentile(
     return data[fl] + (data[ce] - data[fl]) * (c + d * fractional_part(x))
 
 
-def mad(data: List[Union[int, float]]) -> float:
+def mad(data: List[Numeric]) -> float:
     """
     Calculates the median absolute deviation (MAD) of a list of values
     :param data: list of values
@@ -63,10 +63,8 @@ def mad(data: List[Union[int, float]]) -> float:
 
 
 def interquartile_range(
-    data: List[Union[int, float]],
-    params: Tuple[
-        Union[int, float], Union[int, float], Union[int, float], Union[int, float]
-    ] = (0, 0, 1, 0),
+    data: List[Numeric],
+    params: Tuple[Numeric, Numeric, Numeric, Numeric] = (0, 0, 1, 0),
 ) -> float:
     """
     Calculates the interquartile range (q3 - q1) of a list of values

--- a/elastalert/utils/arithmetic.py
+++ b/elastalert/utils/arithmetic.py
@@ -77,11 +77,11 @@ def interquartile_range(
     return percentile(data, 0.75, params) - percentile(data, 0.25, params)
 
 
-def gcd(a, b):
-    if b == 0:
+def gcd(a, b, zero_value=0):
+    if b == zero_value:
         return a
     else:
-        return gcd(b, a % b)
+        return gcd(b, a % b, zero_value)
 
 
 class Mapping:

--- a/elastalert/utils/arithmetic.py
+++ b/elastalert/utils/arithmetic.py
@@ -1,0 +1,99 @@
+from math import ceil, floor, sqrt
+from typing import List, Union
+
+
+def mean(data: List[Union[int, float]]) -> float:
+    """
+    Calculates the mean over the list values
+    :param data: list of values
+    :return: the mean
+    """
+    return sum(data) / len(data)
+
+
+def median(data: List[Union[int, float]]) -> float:
+    """
+    Calculates the median over a list of values
+    :param data: list of values
+    :return: the median
+    """
+    return percentile(data, 0.5)
+
+
+def percentile(data: List[Union[int, float]], percentile: float = 0.95) -> float:
+    """
+    Calculates the nth percentile of a list of values
+    :param data: list of values
+    :param percentile: the percentile as float between 0 and 1, default is 0.95
+    :return: the nth percentile
+    """
+    if percentile < 0 or percentile > 1:
+        raise ValueError("percentile value must be between 0 and 100")
+    data = sorted(data)
+    k = (len(data) - 1) * percentile
+    f = floor(k)
+    c = ceil(k)
+    if f == c:
+        return float(data[int(k)])
+    d0 = data[int(f)] * (c - k)
+    d1 = data[int(c)] * (k - f)
+    return d0 + d1
+
+
+def variance(data: List[Union[int, float]]) -> float:
+    """
+    Calculates the variance of a list of values
+    :param data: the list of values
+    :return: the variance
+    """
+    m = mean(data)
+    return sum((xi - m) ** 2 for xi in data) / len(data)
+
+
+def standard_deviation(data: List[Union[int, float]]) -> float:
+    """
+    Calculates the standard deviation of a list of values
+    :param data: list of values
+    :return: the standard derivation
+    """
+    return sqrt(variance(data))
+
+
+def mad(data: List[Union[int, float]]) -> float:
+    """
+    Calculates the median absolute deviation (MAD) of a list of values
+    :param data: list of values
+    :return: the MAD
+    """
+    m = median(data)
+    return median([abs(xi - m) for xi in data])
+
+
+def interquartile_range(data: List[Union[int, float]]) -> float:
+    """
+    Calculates the interquartile range (q3 - q1) of a list of values
+    :param data: list of values
+    :return: the interquartile range
+    """
+    return percentile(data, 0.75) - percentile(data, 0.25)
+
+
+def gcd(a, b):
+    if b == 0:
+        return a
+    else:
+        return gcd(b, a % b)
+
+
+mapping = {
+    "mean": mean,
+    "median": median,
+    "sum": sum,
+    "min": min,
+    "max": max,
+    "percentiles": percentile,
+    "variance": variance,
+    "MAD": mad,
+    "standard_derivation": standard_deviation,
+    "interquartile_range": interquartile_range,
+}

--- a/elastalert/utils/event_window.py
+++ b/elastalert/utils/event_window.py
@@ -25,20 +25,23 @@ class EventWindow:
         self.data = sortedlist(key=self.get_ts)
         self.running_count = 0
 
+    def clean_old_events(self):
+        """Removes old events"""
+        while self.data and self.duration() >= self.timeframe:
+            oldest = self.data[0]
+            self.data.remove(oldest)
+            self.running_count -= oldest[1]
+            self.on_removed and self.on_removed(oldest)
+
     def append(self, event: Tuple[dict, int]):
         """ Add an event to the window. Event should be of the form (dict, count).
         This will also pop the oldest events and call onRemoved on them until the
         window size is less than timeframe. """
         self.data.add(event)
         self.running_count += event[1]
+        self.clean_old_events()
 
-        while self.duration() >= self.timeframe:
-            oldest = self.data[0]
-            self.data.remove(oldest)
-            self.running_count -= oldest[1]
-            self.on_removed and self.on_removed(oldest)
-
-    def duration(self):
+    def duration(self) -> datetime.timedelta:
         """ Get the size in timedelta of the window. """
         if not self.data:
             return datetime.timedelta(0)

--- a/tests/queries/elasticsearch_query_test.py
+++ b/tests/queries/elasticsearch_query_test.py
@@ -1,5 +1,3 @@
-from unittest import TestCase
-
 from elastalert.queries.elasticsearch_query import ElasticsearchQuery
 
 

--- a/tests/utils/util_test.py
+++ b/tests/utils/util_test.py
@@ -1,18 +1,20 @@
 from datetime import datetime, timedelta
 from math import sqrt
+from statistics import StatisticsError, harmonic_mean
 from unittest import TestCase
 
 import mock
 import pytest
 from dateutil.parser import parse as dt
 from elastalert.utils.arithmetic import (
+    Mapping,
     fractional_part,
     interquartile_range,
     mad,
     mean,
     median,
     percentile,
-    standard_deviation,
+    stdev,
     variance,
 )
 from elastalert.utils.util import (
@@ -220,20 +222,6 @@ def test_fractional_part():
     assert fractional_part(100.1234) == 0.1234
 
 
-def test_mean():
-    assert mean([1, 2, 3, 4, 5, 6, 7, 8]) == 9 / 2
-    assert mean([1]) == 1
-    with pytest.raises(ValueError):
-        mean([])
-
-
-def test_median():
-    assert median([1, 2, 3, 4, 5, 6, 7, 8]) == 9 / 2
-    assert median([1, 2, 3, 4, 5, 6, 7, 20]) == 9 / 2
-    with pytest.raises(ValueError):
-        median([])
-
-
 def test_percentile():
     assert percentile([1], 0.25) == 1
     assert percentile([1], 0.25, (0, 0, 0, 1)) == 1
@@ -244,31 +232,19 @@ def test_percentile():
     assert percentile([1, 1, 3, 5], 0.7, (1 / 2, 0, 0, 0)) == 3
     assert percentile([1, 1, 3, 5], 0.7, (1 / 2, 0, 0, 1)) == 3.6
     assert percentile([1, 1, 3, 5], 0.99, (0, 0, 0, 1)) == 4.92
-    with pytest.raises(ValueError):
+    with pytest.raises(StatisticsError):
         percentile([])
-
-
-def test_variance():
-    assert variance([1, 2, 3, 4, 5, 6, 7, 8]) == 6
-    TestCase().assertAlmostEqual(208 / 21, variance([10, 10, 10, 15, 15, 16, 17]))
-    assert variance([5, 63]) == 1682
-    with pytest.raises(ValueError):
-        variance([5])
-
-
-def test_standard_deviation():
-    assert standard_deviation([1, 2, 3, 4, 5, 6, 7, 8]) == sqrt(6)
-    assert standard_deviation([1, 2, 3, 4, 5, 6, 7, 20]) == 6
-    TestCase().assertAlmostEqual(29 * sqrt(2), standard_deviation([5, 63]))
-    with pytest.raises(ValueError):
-        standard_deviation([5])
+    with pytest.raises(StatisticsError):
+        percentile([1, 2, 3, 4], 1.1)
+    with pytest.raises(StatisticsError):
+        percentile([1, 2, 3, 4], -0.01)
 
 
 def test_mad():
     assert mad([1, 2, 3, 4]) == 1
     assert mad([100]) == 0
     assert mad([0, 100]) == 50
-    with pytest.raises(ValueError):
+    with pytest.raises(StatisticsError):
         mad([])
 
 
@@ -279,5 +255,11 @@ def test_interquartile_range():
     assert interquartile_range([1, 1, 3, 5, 4], (0, 0, 0, 1)) == 11 / 4
     assert interquartile_range([1, 1, 3, 5, 4], (1 / 2, 0, 0, 1)) == 13 / 4
     assert interquartile_range([1, 1, 3, 5, 4], (1 / 2, 0, 0, 0)) == 3
-    with pytest.raises(ValueError):
+    with pytest.raises(StatisticsError):
         interquartile_range([])
+
+
+def test_arithmetic_mapping():
+    assert Mapping.get("stdev") == stdev
+    assert Mapping.get("not_found", "default") == "default"
+    assert Mapping.get("statistics.harmonic_mean") == harmonic_mean


### PR DESCRIPTION
- Gap timeframe between current window and reference window
- Possibility to have multiple buckets as a reference window, calculate a statistical metric over these buckets and then compare this metric with the current window.

Removed the field_value option. This functionality will be implemented in the SpikeMetricAggregation rule.